### PR TITLE
Add a Currently Equipped warning window

### DIFF
--- a/LootFilter/RiftAddon.toc
+++ b/LootFilter/RiftAddon.toc
@@ -4,7 +4,7 @@ Description = "Loot Filter is designed to destroy all selected items whenever th
 
 Author = "Vueren#9253"
 Email = "vueren@pm.me"
-Version = "0.9.3"
+Version = "0.9.4"
 Environment = "4.5"
 
 --@no-lib-strip@
@@ -27,6 +27,7 @@ SavedVariables = {
 
 RunOnStartup = {
 	"UI/General.lua",
+	"UI/CurrentlyEquippedWarning.lua",
 	"UI/InventoryConfig.lua",
 	"UI/SelectedItemsConfig.lua",
 	"UI/AutoDeleteConfirmation.lua",

--- a/LootFilter/UI/CurrentlyEquippedWarning.lua
+++ b/LootFilter/UI/CurrentlyEquippedWarning.lua
@@ -1,0 +1,73 @@
+local addon, LF = ...
+
+if LF.UI == nil then
+    LF.UI = {}
+end
+LF.UI.CurrentlyEquippedWarning = {}
+LF.UI.CurrentlyEquippedWarning.Window = nil -- the window to alert that a selected item is currently equipped
+LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle = nil -- the text to warn the user that a selected item is currently equipped
+LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications = nil -- the text to warn the user why it's bad that that a selected item is currently equipped
+LF.UI.CurrentlyEquippedWarning.OKButton = nil -- the OK button to close the window
+
+-- Currently equipped warning window
+LF.UI.CurrentlyEquippedWarning.CreateCurrentlyEquippedWarningWindow = function()
+    -- Create a hidden confirmation window
+    if LF.UI.CurrentlyEquippedWarning.Window == nil then
+        LF.UI.CurrentlyEquippedWarning.Window = UI.CreateFrame('SimpleWindow', 'LF.UI.CurrentlyEquippedWarning.Window', LF.UI.General.Context)
+        LF.UI.CurrentlyEquippedWarning.Window:SetCloseButtonVisible(true)
+        LF.UI.CurrentlyEquippedWarning.Window.closeButton:EventAttach(Event.UI.Input.Mouse.Left.Click, function(self, h)
+            -- Remove all warning UI
+            LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle:SetVisible(false)
+            LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications:SetVisible(false)
+            LF.UI.CurrentlyEquippedWarning.OKButton:SetVisible(false)
+            LF.UI.CurrentlyEquippedWarning.Window:SetVisible(false)
+        end, 'CloseLeftClick')
+    end
+    LF.UI.CurrentlyEquippedWarning.Window:SetVisible(true)
+    LF.UI.CurrentlyEquippedWarning.Window:SetTitle('WARNING - CURRENTLY EQUIPPED!')
+    LF.UI.CurrentlyEquippedWarning.Window:SetWidth(600)
+    LF.UI.CurrentlyEquippedWarning.Window:SetHeight(135)
+    LF.UI.CurrentlyEquippedWarning.Window:SetLayer(20)
+
+    -- Put the warning window to the middle of the screen
+    LF.UI.CurrentlyEquippedWarning.Window:SetPoint(
+        'TOPLEFT', UIParent, 'TOPLEFT',
+        (UIParent:GetWidth()/2) - (LF.UI.CurrentlyEquippedWarning.Window:GetWidth()/2),
+        (UIParent:GetHeight()/2) - (LF.UI.CurrentlyEquippedWarning.Window:GetHeight()/2)
+    )
+
+    -- Text disclaimer to inform the user that a currently equipped item was selected
+    if LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle == nil then
+        LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle = UI.CreateFrame('Text', 'LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle', LF.UI.CurrentlyEquippedWarning.Window)
+    end
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle:SetVisible(true)
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle:SetFontSize(14)
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle:SetPoint('TOPCENTER', LF.UI.CurrentlyEquippedWarning.Window, 'TOPCENTER', 0, 50)
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle:SetText('Gear that was selected in this bag is also currently equipped by the character!')
+
+    -- Text disclaimer to inform the user why it's bad that that a selected item is currently equipped
+    if LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications == nil then
+        LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications = UI.CreateFrame('Text', 'LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications', LF.UI.CurrentlyEquippedWarning.Window)
+    end
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications:SetVisible(true)
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications:SetFontSize(14)
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications:SetPoint('TOPCENTER', LF.UI.CurrentlyEquippedWarning.Window, 'TOPCENTER', 0, 72)
+    LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications:SetText('If you begin auto deleting, unequipping that version of the gear WILL auto delete it!')
+
+    -- Add the OK button
+    if LF.UI.CurrentlyEquippedWarning.OKButton == nil then
+        LF.UI.CurrentlyEquippedWarning.OKButton = UI.CreateFrame('RiftButton', 'LF.UI.CurrentlyEquippedWarning.OKButton', LF.UI.CurrentlyEquippedWarning.Window)
+        -- Close window once OK is clicked
+        LF.UI.CurrentlyEquippedWarning.OKButton:EventAttach(Event.UI.Input.Mouse.Left.Click, function(self, h)
+            -- Remove all warning UI
+            LF.UI.CurrentlyEquippedWarning.EquippedWarningTextSubtitle:SetVisible(false)
+            LF.UI.CurrentlyEquippedWarning.EquippedWarningTextImplications:SetVisible(false)
+            LF.UI.CurrentlyEquippedWarning.OKButton:SetVisible(false)
+            LF.UI.CurrentlyEquippedWarning.Window:SetVisible(false)
+        end, 'Start Left Click')
+    end
+    LF.UI.CurrentlyEquippedWarning.OKButton:SetVisible(true)
+    LF.UI.CurrentlyEquippedWarning.OKButton:SetText('OK')
+    LF.UI.CurrentlyEquippedWarning.OKButton:SetPoint('BOTTOMCENTER', LF.UI.CurrentlyEquippedWarning.Window, 'BOTTOMCENTER', 0, -11)
+end
+

--- a/LootFilter/UI/InventoryConfig.lua
+++ b/LootFilter/UI/InventoryConfig.lua
@@ -70,6 +70,12 @@ LF.UI.InventoryConfig.DisplayItem = function(bagSlot, itemSlot, posX, posY)
                             icon = idetail.icon,
                             rarity = idetail.rarity
                         }
+                        -- Check if the item is currently equipped
+                        for itype,_ in pairs(LF.Utility.GetEquippedItemsList()) do
+                            if idetail.type == itype then
+                                LF.UI.CurrentlyEquippedWarning.CreateCurrentlyEquippedWarningWindow()
+                            end
+                        end
                         LF.Settings.PushUpdatesToSavedVariables()
                     else
                         LF.Settings.SelectedItems[idetail.type] = nil
@@ -203,6 +209,7 @@ end
 LF.UI.InventoryConfig.ToggleSelectAllItemsInBag = function(bagSlotNum)
     -- Check if the bag exists
     local bag = Inspect.Item.Detail(Utility.Item.Slot.Inventory('bag', bagSlotNum))
+    local currentlyEquippedItemSelected = false
     local itemsToDeselect = {}
     local unselectedItemFound = false
     if bag ~= nil then
@@ -218,6 +225,12 @@ LF.UI.InventoryConfig.ToggleSelectAllItemsInBag = function(bagSlotNum)
                         rarity = idetail.rarity
                     }
                     LF.Settings.PushUpdatesToSavedVariables()
+                    -- Check if the item is currently equipped
+                    for itype,_ in pairs(LF.Utility.GetEquippedItemsList()) do
+                        if idetail.type == itype then
+                            currentlyEquippedItemSelected = true
+                        end
+                    end
                     unselectedItemFound = true
                 else
                     itemsToDeselect[idetail.type] = {
@@ -234,6 +247,11 @@ LF.UI.InventoryConfig.ToggleSelectAllItemsInBag = function(bagSlotNum)
         for idetailType,_ in pairs(itemsToDeselect) do
             LF.Settings.SelectedItems[idetailType] = nil
             LF.Settings.PushUpdatesToSavedVariables()
+        end
+    else
+        -- A currently equipped item got Selected. Make sure to warn the user!
+        if currentlyEquippedItemSelected == true then
+            LF.UI.CurrentlyEquippedWarning.CreateCurrentlyEquippedWarningWindow()
         end
     end
 end

--- a/LootFilter/Utility/Utility.lua
+++ b/LootFilter/Utility/Utility.lua
@@ -85,6 +85,26 @@ LF.Utility.GetNumberOfSelectedItemsInInventory = function()
     return numItems
 end
 
+-- Gets the items that are currently equipped
+LF.Utility.GetEquippedItemsList = function()
+    local equippedItems = {}
+    for ikey,ival in pairs(Inspect.Item.List(Utility.Item.Slot.Equipment())) do
+        -- Does not apply to empty equipment slots.
+        -- Only applies to items currently equipped.
+        -- Does not apply to Fragments.
+        local itemLocation,equipSlot = Utility.Item.Slot.Parse(ikey)
+        if(
+            ival ~= false
+            and itemLocation == 'equipment'
+            and not string.match(equipSlot, '^fragment')
+        ) then
+            local idetail = Inspect.Item.Detail(ikey) -- Get the current item details.
+            equippedItems[idetail.type] = idetail -- Save them by type
+        end
+    end
+    return equippedItems
+end
+
 -- Deletes the item if permitted. Returns true if item was deleted.
 LF.Utility.DeleteItem = function(idetail)
     if LF.Settings.AutoDeleting then
@@ -320,6 +340,42 @@ LF.Utility.SlashHandlerIDetail = function(_, params)
             else
                 print('No bag in this slot!')
             end
+        -- User wants to display information about a specific equipped item y (/idetail equipment y)
+        elseif
+            sanitizedArgs[1] == 'equipment'
+            and (
+                sanitizedArgs[2] == 'helmet' or
+                sanitizedArgs[2] == 'cape' or
+                sanitizedArgs[2] == 'shoulders' or
+                sanitizedArgs[2] == 'chest' or
+                sanitizedArgs[2] == 'gloves' or
+                sanitizedArgs[2] == 'belt' or
+                sanitizedArgs[2] == 'legs' or
+                sanitizedArgs[2] == 'feet' or
+                sanitizedArgs[2] == 'handmain' or
+                sanitizedArgs[2] == 'handoff' or
+                sanitizedArgs[2] == 'ranged' or
+                sanitizedArgs[2] == 'neck' or
+                sanitizedArgs[2] == 'trinket' or
+                sanitizedArgs[2] == 'ring1' or
+                sanitizedArgs[2] == 'ring2' or
+                sanitizedArgs[2] == 'earring1' or
+                sanitizedArgs[2] == 'earring2' or
+                sanitizedArgs[2] == 'synergy' or
+                sanitizedArgs[2] == 'focus' or
+                sanitizedArgs[2] == 'seal'
+            )
+        then
+            local idetail = Inspect.Item.Detail(Utility.Item.Slot.Equipment(sanitizedArgs[2]))
+            if idetail ~= nil then
+                print('===')
+                for k,v in pairs(idetail) do
+                    print(tostring(k) .. ': ' .. tostring(v))
+                end
+                print('===')
+            else
+                print('No item in this equipment slot!')
+            end
         end
     -- User wants to inspect all items in a specific bag x (/idetail x)
     elseif
@@ -337,6 +393,25 @@ LF.Utility.SlashHandlerIDetail = function(_, params)
             ) then
                 local idetail = Inspect.Item.Detail(ikey) -- Get the current item details.
                 print(idetail.name .. ': ' .. ikey .. ' | ' .. ival .. ' | ' .. bagSlot .. ' | ' .. itemSlot)
+            end
+        end
+    -- User wants to inspect all gear items (/idetail equipment)
+    elseif
+        #sanitizedArgs == 1
+        and sanitizedArgs[1] == 'equipment'
+    then
+        for ikey,ival in pairs(Inspect.Item.List(Utility.Item.Slot.Equipment())) do
+            -- Does not apply to empty equipment slots.
+            -- Only applies to items currently equipped.
+            -- Does not apply to Fragments.
+            local itemLocation,equipSlot = Utility.Item.Slot.Parse(ikey)
+            if(
+                ival ~= false
+                and itemLocation == 'equipment'
+                and not string.match(equipSlot, '^fragment')
+            ) then
+                local idetail = Inspect.Item.Detail(ikey) -- Get the current item details.
+                print(idetail.name .. ': ' .. ikey .. ' | ' .. ival .. ' | ' .. equipSlot)
             end
         end
     -- Display basic info about all items in the entire inventory to the user (/idetail *or* an unrecognized command)


### PR DESCRIPTION
Updates Addon version to Beta v0.9.4

This version adds a warning window to inform the user that they have just selected an item that they also currently have equipped.